### PR TITLE
fix: link to java.exe for windows systems

### DIFF
--- a/packages/openjdk-17/package.yaml
+++ b/packages/openjdk-17/package.yaml
@@ -28,6 +28,6 @@ source:
     - target: win
       files:
         openjdk-17.0.2.zip: https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_windows-x64_bin.zip
-      bin: jdk-17.0.2/bin/java
+      bin: jdk-17.0.2/bin/java.exe
 bin:
   java: "{{source.download.bin}}"


### PR DESCRIPTION
fix: link to java.exe for windows systems

On windows systems, the installation of openjdk-17 fails with the following message:

```
Tried to link bin "java" to non-existent target "jdk-17.0.2/bin/java".
```

The binary within the downloaded package for windows is `java.exe` and not `java`.