### PR TITLE
feat: bump up jdtls version

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -10,19 +10,19 @@ categories:
   - LSP
 
 source:
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.37.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.38.0
   download:
     - target: [darwin_x64, darwin_arm64]
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202406271335.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202408011337.tar.gz
       config: config_mac/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202406271335.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202408011337.tar.gz
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202406271335.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202408011337.tar.gz
       config: config_win/
 
 schemas:


### PR DESCRIPTION
Reference: https://github.com/mason-org/mason-registry/blob/main/packages/jdtls/package.yaml

Question: Is it also required to update it here in nvim-java https://github.com/nvim-java/nvim-java/blob/b3174e41ab51867123d8663eced53b33f1548522/lua/java/startup/mason-dep.lua#L52 ?